### PR TITLE
Speed and Error Improvements 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,11 @@ module.exports = homebridge => {
         systemID,
         targets,
         compositeTargets,
+        delay,
       } = normalizeConfiguration(config);
 
       const client = new SomfySynergy(systemID, ipAddress);
-      this.synergy = new SomfySynergy.Platform(client, compositeTargets);
+      this.synergy = new SomfySynergy.Platform(client, compositeTargets, delay);
       this.targets = targets;
     }
 
@@ -42,6 +43,7 @@ module.exports = homebridge => {
     systemID,
     targets,
     compositeTargets,
+    delay,
   }) => {
     const normalConfig = {
       ipAddress: 'undefined',
@@ -58,6 +60,11 @@ module.exports = homebridge => {
       normalConfig.systemID = systemID;
     } else {
       this.log('Bad `config.systemID` value, must be a string.');
+    }
+    if (typeof delay === 'number') {
+      normalConfig.delay = delay;
+    } else if (typeof delay !== 'undefined') {
+      this.log('Bad `config.delay` value, must be a number.');
     }
     if (Array.isArray(targets)) {
       targets.forEach((target, index) => {


### PR DESCRIPTION
Accidentally closed #6, sorry!

* Add delay option to be passes along to SomfySynergyPlatform. For anyone not using composite targets it is nice to be able to set the delay to 0. I would even consider setting it to 0 by default if there are no composite targets.
* Pass along errors from synergy to HomeKit. Without calling the callback with the error, HomeKit gets stuck in a perpetual state of "opening" or "closing".
* Maintain currentValue internally. This allows us to handle a get request for currentPosition, which is what HomeKit uses to determine if the accessory is still responsive or not.