### PR TITLE
Homebridge 2.0 and Node 18/20/22 engine support

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     }
   },
   "engines": {
-    "homebridge": ">=1",
-    "node": ">=12"
+    "homebridge": "^1.6.0 || ^2.0.0-beta.0",
+    "node": "^18.20.4 || ^20.15.1 || ^22"
   },
   "devDependencies": {
     "@types/node": "16.9.2",


### PR DESCRIPTION
Summary:
  Updates the plugin to be compatible and compliant with Homebridge 2.0
  by changing only the engines field in package.json. No other code
  changes were required.

Changes:
  - engines.homebridge: ">=1" -> "^1.6.0 || ^2.0.0-beta.0"
  - engines.node: ">=12" -> "^18.20.4 || ^20.15.1 || ^22"

Reference: Updating To Homebridge v2.0 wiki.

Why no other code changes:
  - HAP-NodeJS v1: The breaking change for plugins is using
    api.hap.Perms/Formats/Units instead of Characteristic.Perms/Formats/
    Units. This plugin does not use those enums; it only uses Service
    and Characteristic types and value constants (e.g. PositionState),
    which remain valid. The plugin already uses the HAP instance from
    Homebridge (setHap(homebridge.hap)), so no HAP usage changes were
    needed.

  - Deprecated Core/BridgedCore: The plugin does not use these.

  - Homebridge plugin API: Registration, api.platformAccessory, and
    platform/accessory setup follow documented patterns and do not
    rely on removed or changed APIs in 2.0.

The only change required for 2.0 compliance was declaring support in
package.json via the engines field.